### PR TITLE
Add additional AD40xx parts including support for dynamic sampling frequency

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,ad400x.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad400x.yaml
@@ -12,19 +12,37 @@ maintainers:
 description: |
   Analog Devices AD400X family Analog to Digital Converters with SPI support.
   Specifications can be found at:
+    https://www.analog.com/en/products/ad4001.html
+    https://www.analog.com/en/products/ad4002.html
     https://www.analog.com/en/products/ad4003.html
+    https://www.analog.com/en/products/ad4004.html
+    https://www.analog.com/en/products/ad4005.html
+    https://www.analog.com/en/products/ad4006.html
     https://www.analog.com/en/products/ad4007.html
+    https://www.analog.com/en/products/ad4008.html
+    https://www.analog.com/en/products/ad4010.html
     https://www.analog.com/en/products/ad4011.html
     https://www.analog.com/en/products/ad4020.html
+    https://www.analog.com/en/products/ad4021.html
+    https://www.analog.com/en/products/ad4022.html
     https://www.analog.com/en/products/adaq4003.html
 
 properties:
   compatible:
     enum:
+      - adi,ad4001
+      - adi,ad4002
       - adi,ad4003
+      - adi,ad4004
+      - adi,ad4005
+      - adi,ad4006
       - adi,ad4007
+      - adi,ad4008
+      - adi,ad4010
       - adi,ad4011
       - adi,ad4020
+      - adi,ad4021
+      - adi,ad4022
       - adi,adaq4003
 
   reg: true

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -46,12 +46,29 @@
 		};
 	};
 
+	adc_trigger: pwm@44b00000 {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "adc_conversion_trigger";
+		#pwm-cells = <2>;
+		clocks = <&spi_clk>;
+	};
+
+	spi_clk: clock-controller@44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
 	axi_spi_engine_0: spi@44a00000 {
 		compatible = "adi,axi-spi-engine-1.00.a";
 		reg = <0x44a00000 0x1000>;
 		interrupt-parent = <&intc>;
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 15 &clkc 17>;
+		clocks = <&clkc 15 &spi_clk>;
 		clock-names = "s_axi_aclk", "spi_clk";
 		num-cs = <1>;
 
@@ -59,12 +76,16 @@
 		#size-cells = <0x0>;
 
 		ad4020: adc@0 {
-			compatible = "ad4020";
+			compatible = "adi,ad4020";
 			reg = <0>;
-			spi-max-frequency = <71000000>;
+			spi-max-frequency = <102000000>;
 
+			clocks = <&spi_clk>;
+			clock-names = "ref_clk";
 			dmas = <&rx_dma 0>;
 			dma-names = "rx";
+			pwms = <&adc_trigger 0 0>;
+			pwm-names = "cnv";
 
 			vref-supply = <&vref>;
 			#io-channel-cells = <1>;

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -145,8 +145,8 @@ static int ad400x_read_sample(struct ad400x_state *st, uint32_t *val)
 	if (ret < 0)
 		return ret;
 
-	dev_info(&st->spi->dev, "read: %u", *val);
 	*val = (input[2] << 16) | (input[1] << 8) | input[0];
+	dev_info(&st->spi->dev, "read: %u", *val);
 
 	return ret;
 }


### PR DESCRIPTION
My goal for this PR is to allow @machschmitt and myself to sync up on the support for the AD40xx parts and the ADAQ4003.

This PR adds support for additional AD40xx parts and allows sampling frequency to be modified:
```
AD4000 AD4001 AD4002 AD4004 AD4005 AD4006 AD4008 AD4010 AD4021 AD4022
```

* Notes:
  * This is based somewhat on my original PR https://github.com/analogdevicesinc/linux/pull/2257 which attempted to add dynamic sampling frequency
  * I have rewritten the code in that PR to sit on top of the work @machschmitt has done for the ADAQ4003 as @machschmitt already added the dynamic sampling frequency infrastructure.
  * This PR is specifically based on testing/adaq4003 instead of dev/adaq4003 because the testing branch has newer commits
  * I don't consider this PR to in a merge-able state.  I feel I would need to break these changes into smaller commits.

* References:
  * GitHub issue: [Extend support for AD40xx with variable sample frequency #2239](https://github.com/analogdevicesinc/linux/issues/2239)
  *  Requires PWM peripheral in the updated BOOT.BIN (from @acostina in https://github.com/adi-ses/sea-misc/pull/27) that will be merged into the public HDL project