### PR TITLE
Add additional AD40xx parts

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,ad400x.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad400x.yaml
@@ -12,19 +12,37 @@ maintainers:
 description: |
   Analog Devices AD400X family Analog to Digital Converters with SPI support.
   Specifications can be found at:
+    https://www.analog.com/en/products/ad4001.html
+    https://www.analog.com/en/products/ad4002.html
     https://www.analog.com/en/products/ad4003.html
+    https://www.analog.com/en/products/ad4004.html
+    https://www.analog.com/en/products/ad4005.html
+    https://www.analog.com/en/products/ad4006.html
     https://www.analog.com/en/products/ad4007.html
+    https://www.analog.com/en/products/ad4008.html
+    https://www.analog.com/en/products/ad4010.html
     https://www.analog.com/en/products/ad4011.html
     https://www.analog.com/en/products/ad4020.html
+    https://www.analog.com/en/products/ad4021.html
+    https://www.analog.com/en/products/ad4022.html
     https://www.analog.com/en/products/adaq4003.html
 
 properties:
   compatible:
     enum:
+      - adi,ad4001
+      - adi,ad4002
       - adi,ad4003
+      - adi,ad4004
+      - adi,ad4005
+      - adi,ad4006
       - adi,ad4007
+      - adi,ad4008
+      - adi,ad4010
       - adi,ad4011
       - adi,ad4020
+      - adi,ad4021
+      - adi,ad4022
       - adi,adaq4003
 
   reg: true

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -46,12 +46,29 @@
 		};
 	};
 
+	adc_trigger: pwm@44b00000 {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "adc_conversion_trigger";
+		#pwm-cells = <2>;
+		clocks = <&spi_clk>;
+	};
+
+	spi_clk: axi-clkgen@44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
 	axi_spi_engine_0: spi@44a00000 {
 		compatible = "adi,axi-spi-engine-1.00.a";
 		reg = <0x44a00000 0x1000>;
 		interrupt-parent = <&intc>;
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 15 &clkc 17>;
+		clocks = <&clkc 15 &spi_clk>;
 		clock-names = "s_axi_aclk", "spi_clk";
 		num-cs = <1>;
 
@@ -59,12 +76,16 @@
 		#size-cells = <0x0>;
 
 		ad4020: adc@0 {
-			compatible = "ad4020";
+			compatible = "adi,ad4020";
 			reg = <0>;
-			spi-max-frequency = <71000000>;
+			spi-max-frequency = <102000000>;
 
+			clocks = <&spi_clk>;
+			clock-names = "ref_clk";
 			dmas = <&rx_dma 0>;
 			dma-names = "rx";
+			pwms = <&adc_trigger 0 0>;
+			pwm-names = "cnv";
 
 			vref-supply = <&vref>;
 			#io-channel-cells = <1>;

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -458,7 +458,7 @@ static int ad400x_enable_cnv_trigger(struct ad400x_state *st, bool enable)
 	return pwm_apply_state(st->cnv_trigger, &cnv_state);
 }
 
-static int ad400x_buffer_postenable(struct iio_dev *indio_dev)
+static int ad400x_buffer_preenable(struct iio_dev *indio_dev)
 {
 	struct ad400x_state *st = iio_priv(indio_dev);
 	int ret;
@@ -508,7 +508,7 @@ static const struct iio_dma_buffer_ops dma_buffer_ops = {
 };
 
 static const struct iio_buffer_setup_ops ad400x_buffer_setup_ops = {
-	.postenable = &ad400x_buffer_postenable,
+	.preenable = &ad400x_buffer_preenable,
 	.postdisable = &ad400x_buffer_postdisable,
 };
 

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -70,14 +70,6 @@ enum ad400x_ids {
 	ID_ADAQ4003,
 };
 
-static const struct iio_chan_spec ad400x_channels[] = {
-	AD400X_CHANNEL(18),
-};
-
-static const struct iio_chan_spec ad4020_channel[] = {
-	AD400X_CHANNEL(20),
-};
-
 struct ad400x_chip_info {
 	struct iio_chan_spec chan_spec;
 	int max_rate;

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -416,21 +416,18 @@ static const struct iio_info ad400x_info = {
 };
 
 static const struct spi_device_id ad400x_id[] = {
-	{"ad4000", ID_AD4000},
-	{"ad4001", ID_AD4001},
-	{"ad4002", ID_AD4002},
-	{"ad4003", ID_AD4003},
-	{"ad4004", ID_AD4004},
-	{"ad4005", ID_AD4005},
-	{"ad4006", ID_AD4006},
-	{"ad4007", ID_AD4007},
-	{"ad4008", ID_AD4008},
-	{"ad4010", ID_AD4010},
-	{"ad4011", ID_AD4011},
-	{"ad4020", ID_AD4020},
-	{"ad4021", ID_AD4021},
-	{"ad4022", ID_AD4022},
-	{"adaq4003", ID_ADAQ4003},
+	{ "ad4001", (kernel_ulong_t)&ad400x_chips[ID_AD4001] },
+	{ "ad4002", (kernel_ulong_t)&ad400x_chips[ID_AD4002] },
+	{ "ad4003", (kernel_ulong_t)&ad400x_chips[ID_AD4003] },
+	{ "ad4004", (kernel_ulong_t)&ad400x_chips[ID_AD4004] },
+	{ "ad4005", (kernel_ulong_t)&ad400x_chips[ID_AD4005] },
+	{ "ad4006", (kernel_ulong_t)&ad400x_chips[ID_AD4006] },
+	{ "ad4008", (kernel_ulong_t)&ad400x_chips[ID_AD4008] },
+	{ "ad4010", (kernel_ulong_t)&ad400x_chips[ID_AD4010] },
+	{ "ad4020", (kernel_ulong_t)&ad400x_chips[ID_AD4020] },
+	{ "ad4021", (kernel_ulong_t)&ad400x_chips[ID_AD4021] },
+	{ "ad4022", (kernel_ulong_t)&ad400x_chips[ID_AD4022] },
+	{ "adaq4003", (kernel_ulong_t)&ad400x_chips[ID_ADAQ4003] },
 	{}
 };
 MODULE_DEVICE_TABLE(spi, ad400x_id);
@@ -546,10 +543,10 @@ static int pwm_gen_setup(struct spi_device *spi, struct ad400x_state *st)
 
 static int ad400x_probe(struct spi_device *spi)
 {
+	const struct ad400x_chip_info *chip;
 	struct ad400x_state *st;
 	struct iio_dev *indio_dev;
 	struct iio_buffer *buffer;
-	enum ad400x_ids dev_id;
 	const char *p_compat;
 	int ret;
 
@@ -557,14 +554,12 @@ static int ad400x_probe(struct spi_device *spi)
 	if (!indio_dev)
 		return -ENOMEM;
 
-	dev_id = (enum ad400x_ids)device_get_match_data(&spi->dev);
-	if (!dev_id) {
-		dev_id = (enum ad400x_ids)spi_get_device_id(spi)->driver_data;
-		if (!dev_id)
-			return -EINVAL;
-	}
+	chip = (const struct ad400x_chip_info *)device_get_match_data(&spi->dev);
+	if (!chip)
+		return -EINVAL;
 
 	st = iio_priv(indio_dev);
+	st->chip = chip;
 	st->spi = spi;
 	mutex_init(&st->lock);
 
@@ -576,8 +571,6 @@ static int ad400x_probe(struct spi_device *spi)
 	if (ret < 0)
 		return ret;
 
-	st->chip = &ad400x_chips[dev_id];
-
 	ret = devm_add_action_or_reset(&spi->dev, ad400x_regulator_disable, st->vref);
 	if (ret)
 		return ret;
@@ -587,9 +580,9 @@ static int ad400x_probe(struct spi_device *spi)
 	indio_dev->modes = INDIO_DIRECT_MODE | INDIO_BUFFER_HARDWARE;
 	indio_dev->info = &ad400x_info;
 
-	indio_dev->channels = &ad400x_chips[dev_id].chan_spec;
-
+	indio_dev->channels = &st->chip->chan_spec;
 	indio_dev->num_channels = 1;
+
 	st->num_bits = indio_dev->channels->scan_type.realbits;
 
 	/* Set turbo mode */
@@ -628,20 +621,18 @@ static int ad400x_probe(struct spi_device *spi)
 }
 
 static const struct of_device_id ad400x_of_match[] = {
-	{ .compatible = "adi,ad4000", .data = (const void *)ID_AD4000 },
-	{ .compatible = "adi,ad4001", .data = (const void *)ID_AD4001 },
-	{ .compatible = "adi,ad4002", .data = (const void *)ID_AD4002 },
-	{ .compatible = "adi,ad4003", .data = (const void *)ID_AD4003 },
-	{ .compatible = "adi,ad4004", .data = (const void *)ID_AD4004 },
-	{ .compatible = "adi,ad4005", .data = (const void *)ID_AD4005 },
-	{ .compatible = "adi,ad4006", .data = (const void *)ID_AD4006 },
-	{ .compatible = "adi,ad4007", .data = (const void *)ID_AD4007 },
-	{ .compatible = "adi,ad4008", .data = (const void *)ID_AD4008 },
-	{ .compatible = "adi,ad4011", .data = (const void *)ID_AD4011 },
-	{ .compatible = "adi,ad4020", .data = (const void *)ID_AD4020 },
-	{ .compatible = "adi,ad4021", .data = (const void *)ID_AD4021 },
-	{ .compatible = "adi,ad4022", .data = (const void *)ID_AD4022 },
-	{ .compatible = "adi,adaq4003", .data = (const void *)ID_ADAQ4003 },
+	{ .compatible = "adi,ad4001", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_AD4001] },
+	{ .compatible = "adi,ad4002", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_AD4002] },
+	{ .compatible = "adi,ad4003", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_AD4003] },
+	{ .compatible = "adi,ad4004", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_AD4004] },
+	{ .compatible = "adi,ad4005", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_AD4005] },
+	{ .compatible = "adi,ad4006", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_AD4006] },
+	{ .compatible = "adi,ad4008", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_AD4008] },
+	{ .compatible = "adi,ad4010", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_AD4010] },
+	{ .compatible = "adi,ad4020", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_AD4020] },
+	{ .compatible = "adi,ad4021", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_AD4021] },
+	{ .compatible = "adi,ad4022", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_AD4022] },
+	{ .compatible = "adi,adaq4003", .data = (struct ad400x_chip_info *)&ad400x_chips[ID_ADAQ4003] },
 	{ },
 };
 MODULE_DEVICE_TABLE(of, ad400x_of_match);

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -449,11 +449,19 @@ static const struct spi_device_id ad400x_id[] = {
 };
 MODULE_DEVICE_TABLE(spi, ad400x_id);
 
+static int ad400x_enable_cnv_trigger(struct ad400x_state *st, bool enable)
+{
+	struct pwm_state cnv_state;
+
+	pwm_get_state(st->cnv_trigger, &cnv_state);
+	cnv_state.enabled = enable;
+	return pwm_apply_state(st->cnv_trigger, &cnv_state);
+}
+
 static int ad400x_buffer_postenable(struct iio_dev *indio_dev)
 {
 	struct ad400x_state *st = iio_priv(indio_dev);
 	int ret;
-	struct pwm_state conv_state;
 
 	memset(&st->spi_transfer, 0, sizeof(st->spi_transfer));
 	st->spi_transfer.rx_buf = (void *)-1;
@@ -471,25 +479,19 @@ static int ad400x_buffer_postenable(struct iio_dev *indio_dev)
 
 	spi_engine_offload_enable(st->spi, true);
 
-	pwm_get_state(st->cnv_trigger, &conv_state);
-	conv_state.enabled = true;
-	ret = pwm_apply_state(st->cnv_trigger, &conv_state);
-	return 0;
+	return ad400x_enable_cnv_trigger(st, true);
 }
 
 static int ad400x_buffer_postdisable(struct iio_dev *indio_dev)
 {
 	struct ad400x_state *st = iio_priv(indio_dev);
-	struct pwm_state conv_state;
-	int ret;
 
 	spi_engine_offload_enable(st->spi, false);
 
-	pwm_get_state(st->cnv_trigger, &conv_state);
-	conv_state.enabled = false;
-	ret = pwm_apply_state(st->cnv_trigger, &conv_state);
 	st->bus_locked = false;
-	return spi_bus_unlock(st->spi->master);
+	spi_bus_unlock(st->spi->master);
+
+	return ad400x_enable_cnv_trigger(st, false);
 }
 
 static int hw_submit_block(struct iio_dma_buffer_queue *queue,

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -417,12 +417,6 @@ static int ad400x_write_raw(struct iio_dev *indio_dev,
 	}
 }
 
-static const struct iio_info adaq4003_info = {
-	.read_raw = &ad400x_read_raw,
-	.write_raw = &ad400x_write_raw,
-	.debugfs_reg_access = &ad400x_reg_access,
-};
-
 static const struct iio_info ad400x_info = {
 	.read_raw = &ad400x_read_raw,
 	.write_raw = &ad400x_write_raw,
@@ -599,11 +593,7 @@ static int ad400x_probe(struct spi_device *spi)
 	indio_dev->dev.parent = &spi->dev;
 	indio_dev->name = spi_get_device_id(spi)->name;
 	indio_dev->modes = INDIO_DIRECT_MODE | INDIO_BUFFER_HARDWARE;
-
-	if (dev_id == ID_ADAQ4003)
-		indio_dev->info = &adaq4003_info;
-	else
-		indio_dev->info = &ad400x_info;
+	indio_dev->info = &ad400x_info;
 
 	indio_dev->channels = &ad400x_chips[dev_id].chan_spec;
 


### PR DESCRIPTION
I created this new branch [ad400x-add-parts](https://github.com/pdp7/adi-linux/tree/ad400x-add-parts) based on testing/adaq4003.

I squashed all the zynq-zed-adv7511-ad4020.dts changes into one commit.  
* 54c6a92ee55e arch: arm: boot: dts: ad4020: Add pwm node to drive sampling frequency

I also reintroduce functionality from my tree [161b202](https://github.com/pdp7/adi-linux/tree/161b2025743ac64ee052eb0a1229a4a3b9476223) where the spi and of match tables are changed to directly reference the matching ad400x_chip_info:  
* 8414a51e4107 iio: adc: ad400x: use ad400x_info for all parts
* 28c8a866fd00 iio: adc: ad400x: remove unused iio_chan_spec structs
* da73f37d257e iio: adc: ad400x: simplify matching part to ad400x_chip_info
